### PR TITLE
add an action hook after the resolved state of a post is changed

### DIFF
--- a/p2-resolved-posts.php
+++ b/p2-resolved-posts.php
@@ -478,6 +478,7 @@ class P2_Resolved_Posts {
 				'new_state' => $state,
 			);
 		$args = $this->log_state_change( $post_id, $args );
+		 do_action( 'p2_resolved_posts_changed_state', $state, $post_id );
 
 		return $this->single_audit_log_output( $args );
 	}


### PR DESCRIPTION
add an action hook after the state of a post is changed so that others plugins can hook in and add their own functionality as needed. 

Pull request resubmitted from the develop branch as requested (https://github.com/Automattic/P2-Resolved-Posts/pull/12)
