### PR TITLE
Only ouput action links if user is logged in

### DIFF
--- a/p2-resolved-posts.php
+++ b/p2-resolved-posts.php
@@ -420,7 +420,8 @@ class P2_Resolved_Posts {
 		}
 		$output .= '</ul></span>';
 
-		echo $output;
+		if ( is_user_logged_in() )
+			echo $output;
 	}
 
 	/**


### PR DESCRIPTION
Maybe this could be solved smarter and for WP.com it would be great to have somethign like is_private_blog to ouput the action links too - but this would be fast fix for https://github.com/Automattic/P2-Resolved-Posts/issues/5
